### PR TITLE
Add rate limiting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,6 @@ require (
 	github.com/json-iterator/go v1.1.9
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20191222043438-96c4efab7ee2
 	github.com/stretchr/testify v1.5.1
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	nhooyr.io/websocket v1.8.5
 )

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,7 @@ github.com/sumorf/deribit-api v0.0.0-20191024014042-05ddd1385bf2/go.mod h1:5bdqV
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20191024005414-555d28b269f0 h1:/5xXl8Y5W96D+TtHSlonuFqGHIWVuyCkGJLwGh9JJFs=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/models/account_summary.go
+++ b/models/account_summary.go
@@ -14,6 +14,7 @@ type AccountSummary struct {
 	FuturesSessionUpl         float64 `json:"futures_session_upl"`
 	ID                        int     `json:"id"`
 	InitialMargin             float64 `json:"initial_margin"`
+	Limits                    Limits
 	MaintenanceMargin         float64 `json:"maintenance_margin"`
 	MarginBalance             float64 `json:"margin_balance"`
 	OptionsDelta              float64 `json:"options_delta"`
@@ -32,4 +33,40 @@ type AccountSummary struct {
 	TotalPl                   float64 `json:"total_pl"`
 	Type                      string  `json:"type"`
 	Username                  string  `json:"username"`
+}
+
+type Limits struct {
+	LimitsPerCurrency bool `json:"limits_per_currency"`
+	NonMatchingEngine struct {
+		Burst int `json:"burst"`
+		Rate  int `json:"rate"`
+	} `json:"non_matching_engine"`
+	MatchingEngine struct {
+		Trading struct {
+			Total struct {
+				Burst int `json:"burst"`
+				Rate  int `json:"rate"`
+			} `json:"total"`
+		} `json:"trading"`
+		Spot struct {
+			Burst int `json:"burst"`
+			Rate  int `json:"rate"`
+		} `json:"spot"`
+		MaximumQuotes struct {
+			Burst int `json:"burst"`
+			Rate  int `json:"rate"`
+		} `json:"maximum_quotes"`
+		MaximumMassQuotes struct {
+			Burst int `json:"burst"`
+			Rate  int `json:"rate"`
+		} `json:"maximum_mass_quotes"`
+		GuaranteedMassQuotes struct {
+			Burst int `json:"burst"`
+			Rate  int `json:"rate"`
+		} `json:"guaranteed_mass_quotes"`
+		CancelAll struct {
+			Burst int `json:"burst"`
+			Rate  int `json:"rate"`
+		} `json:"cancel_all"`
+	} `json:"matching_engine"`
 }

--- a/rate_limiter.go
+++ b/rate_limiter.go
@@ -1,0 +1,27 @@
+package deribit
+
+import (
+	"context"
+	"golang.org/x/time/rate"
+)
+
+type rateLimiter struct {
+	ctx    context.Context
+	global *rate.Limiter
+	custom *rate.Limiter
+}
+
+func newRateLimiter(ctx context.Context) *rateLimiter {
+	return &rateLimiter{
+		ctx:    ctx,
+		global: rate.NewLimiter(rate.Limit(5), 20),
+		custom: rate.NewLimiter(rate.Limit(0.1), 5),
+	}
+}
+
+func (r *rateLimiter) Wait(method string) error {
+	if method == "public/get_instruments" {
+		return r.custom.Wait(r.ctx)
+	}
+	return r.global.Wait(r.ctx)
+}


### PR DESCRIPTION
Add simple rate limiter to transport layer of client:

1. Limit all requests to 5/s with bursts of 20
2. Separate limiter for pubic/get_instruments method of 0.1/s with bursts of 5

NOTE: This simple limiter does not take into account different credits for matching and non-matching requests, as well as different account tiers.