### PR TITLE
Reserve all credits when hitting a rate limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 # Other
 .idea/
+cmd/

--- a/client.go
+++ b/client.go
@@ -224,7 +224,13 @@ func (c *Client) Call(method string, params interface{}, result interface{}) (er
 		return
 	}
 
-	return c.rpcConn.Call(c.ctx, method, params, result)
+	err = c.rpcConn.Call(c.ctx, method, params, result)
+	var jsonRpcErr *jsonrpc2.Error
+	if errors.As(err, &jsonRpcErr) && jsonRpcErr.Code == 10028 {
+		c.rateLimiter.ReserveAll(method)
+	}
+
+	return
 }
 
 // Handle implements jsonrpc2.Handler

--- a/rate_limiter.go
+++ b/rate_limiter.go
@@ -3,6 +3,7 @@ package deribit
 import (
 	"context"
 	"golang.org/x/time/rate"
+	"time"
 )
 
 type rateLimiter struct {
@@ -24,4 +25,12 @@ func (r *rateLimiter) Wait(method string) error {
 		return r.custom.Wait(r.ctx)
 	}
 	return r.global.Wait(r.ctx)
+}
+
+func (r *rateLimiter) ReserveAll(method string) {
+	if method == "public/get_instruments" {
+		r.custom.ReserveN(time.Now(), 5)
+	} else {
+		r.global.ReserveN(time.Now(), 20)
+	}
 }


### PR DESCRIPTION
On (re)start we assume maximum credits available for burst requests, but this may not always be true.

When hitting a limit we reserve all credits, so we can't do burst requests for the a while.