### PR TITLE
Increase read limit

### DIFF
--- a/client.go
+++ b/client.go
@@ -280,7 +280,7 @@ func (c *Client) connect() (*websocket.Conn, *http.Response, error) {
 	//defer cancel()
 	conn, resp, err := websocket.Dial(ctx, c.addr, &websocket.DialOptions{})
 	if err == nil {
-		conn.SetReadLimit(32768 * 64)
+		conn.SetReadLimit(32768 * 1024)
 	}
 	return conn, resp, err
 }


### PR DESCRIPTION
This should avoid crashing on public/get_instruments without a currency/kind filter applied.